### PR TITLE
Just use ThriftOptions in work parameters

### DIFF
--- a/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/GenerateThriftSourcesWorkAction.java
+++ b/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/GenerateThriftSourcesWorkAction.java
@@ -132,34 +132,34 @@ public abstract class GenerateThriftSourcesWorkAction implements WorkAction<Gene
 
     private void generateKotlinThrifts(Schema schema) throws IOException {
         GenerateThriftSourcesWorkParams params = getParameters();
-        KotlinCodeGenerator gen = new KotlinCodeGenerator(
-                        policyFromNameStyle(params.getNameStyle().get()))
+        ThriftOptions opts = params.getThriftOptions().get();
+        KotlinCodeGenerator gen = new KotlinCodeGenerator(policyFromNameStyle(opts.getNameStyle()))
                 .emitJvmName()
                 .filePerType()
-                .failOnUnknownEnumValues(!params.getIsAllowUnknownEnumValues().get());
+                .failOnUnknownEnumValues(!opts.getAllowUnknownEnumValues());
 
-        if (params.getIsParcelable().get()) {
+        if (opts.getParcelable()) {
             gen.parcelize();
         }
 
-        if (!params.getIsGenerateServiceClients().get()) {
+        if (!opts.getGenerateServiceClients()) {
             gen.omitServiceClients();
         }
 
-        if (params.getIsGenerateServer().get()) {
+        if (opts.isGenerateServer()) {
             gen.generateServer();
         }
 
-        if (params.getListType().isPresent()) {
-            gen.listClassName(params.getListType().get());
+        if (opts.getListType() != null) {
+            gen.listClassName(opts.getListType());
         }
 
-        if (params.getSetType().isPresent()) {
-            gen.setClassName(params.getSetType().get());
+        if (opts.getSetType() != null) {
+            gen.setClassName(opts.getSetType());
         }
 
-        if (params.getMapType().isPresent()) {
-            gen.mapClassName(params.getMapType().get());
+        if (opts.getMapType() != null) {
+            gen.mapClassName(opts.getMapType());
         }
 
         TypeProcessorService typeProcessorService = TypeProcessorService.getInstance();

--- a/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/GenerateThriftSourcesWorkParams.java
+++ b/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/GenerateThriftSourcesWorkParams.java
@@ -39,19 +39,5 @@ public interface GenerateThriftSourcesWorkParams extends WorkParameters {
 
     Property<ShowStacktrace> getShowStacktrace();
 
-    Property<Boolean> getIsGenerateServiceClients();
-
-    Property<FieldNameStyle> getNameStyle();
-
-    Property<String> getListType();
-
-    Property<String> getSetType();
-
-    Property<String> getMapType();
-
-    Property<Boolean> getIsParcelable();
-
-    Property<Boolean> getIsAllowUnknownEnumValues();
-
-    Property<Boolean> getIsGenerateServer();
+    Property<ThriftOptions> getThriftOptions();
 }

--- a/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/ThriftOptions.java
+++ b/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/ThriftOptions.java
@@ -29,6 +29,8 @@ import org.gradle.api.tasks.Optional;
 
 /** Thrift options applicable to all supported languages. */
 public class ThriftOptions implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private boolean generateServiceClients = true;
     private FieldNameStyle nameStyle = FieldNameStyle.DEFAULT;
     private String listType = null;
@@ -37,17 +39,6 @@ public class ThriftOptions implements Serializable {
     private boolean parcelable = false;
     private boolean allowUnknownEnumValues = false;
     private boolean generateServer = false;
-
-    void setWorkerParams(GenerateThriftSourcesWorkParams params) {
-        params.getIsGenerateServiceClients().set(generateServiceClients);
-        params.getNameStyle().set(nameStyle);
-        params.getListType().set(listType);
-        params.getSetType().set(setType);
-        params.getMapType().set(mapType);
-        params.getIsParcelable().set(parcelable);
-        params.getIsAllowUnknownEnumValues().set(allowUnknownEnumValues);
-        params.getIsGenerateServer().set(generateServer);
-    }
 
     @Input
     public boolean getGenerateServiceClients() {

--- a/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/ThriftyTask.java
+++ b/thrifty-gradle-plugin/src/main/java/com/bendb/thrifty/gradle/ThriftyTask.java
@@ -73,7 +73,7 @@ public abstract class ThriftyTask extends SourceTask {
             params.getIncludePath().set(getIncludePath());
             params.getSource().from(getSource());
             params.getShowStacktrace().set(getShowStacktrace());
-            getThriftOptions().get().setWorkerParams(params);
+            params.getThriftOptions().set(getThriftOptions().get());
         });
     }
 }


### PR DESCRIPTION
In #22, we got rid of that annoying `SerializableThriftOptions` type and expressed a wish to further reduce redundant property munging, maybe with AutoValue.  Turns out, AutoValue is a poor fit due to the fact that we use ThriftOptions in a mutable way

Turns out, however, that `ThriftOptions` as used today are perfectly usable in `WorkParameters`, without extra properties or intermediate types!  I don't remember anymore _why_ we needed that second type to begin with; maybe it was the java/kotlin-specific options types that weren't properly serializable?  Clearly I misdiagnosed the problem back then.  Ah well, works now.